### PR TITLE
Update keyboard-modality.js

### DIFF
--- a/src/keyboard-modality.js
+++ b/src/keyboard-modality.js
@@ -10,6 +10,7 @@ document.addEventListener("DOMContentLoaded", function() {
                                       "textarea",
                                       "[role=textbox]",
                                       "[supports-modality=keyboard]"].join(","),
+        isHandlingKeyboardThrottle,
         matcher = (function () {
 			var el = document.body;
 			if (el.matchesSelector)
@@ -49,7 +50,12 @@ document.addEventListener("DOMContentLoaded", function() {
 
     document.body.addEventListener("keydown", function() {
         hadKeyboardEvent = true;
-        setTimeout(function() { hadKeyboardEvent = false; }, 100);
+        if (isHandlingKeyboardThrottle) {
+            clearTimeout(isHandlingKeyboardThrottle);
+        }
+        isHandlingKeyboardThrottle = setTimeout(function() {
+            hadKeyboardEvent = false;
+        }, 100);
     }, true);
 
     document.body.addEventListener("focus", function(e) {


### PR DESCRIPTION
Patch for debouncing the removal of the hadKeyboardEvent flag to prevent rapid-fire keyboarding from racing to remove it too early
